### PR TITLE
LC-API 3.2 compatibility

### DIFF
--- a/Networking.cs
+++ b/Networking.cs
@@ -1,0 +1,72 @@
+﻿using System.Collections.Generic;
+using GameNetcodeStuff;
+using UnityEngine;
+
+namespace PlayerDogModel;
+
+static class Networking
+{
+    public const string ModelSwitchMessageName = "modelswitch";
+    public const string ModelInfoMessageName = "modelinfo";
+
+    public static void Initialize()
+    {
+        LC_API.Networking.Network.RegisterMessage<PlayerModelReplacer.ToggleData>(ModelSwitchMessageName, relayToSelf: false, onReceived: HandleModelSwitchMessage);
+        LC_API.Networking.Network.RegisterMessage(ModelInfoMessageName, relayToSelf: false, onReceived: HandleModelInfoMessage);
+    }
+
+    private static void HandleModelSwitchMessage(ulong senderId, PlayerModelReplacer.ToggleData toggleData)
+    {
+        Debug.Log($"Got {ModelSwitchMessageName} network message from {senderId}: {{ " +
+                  $"{nameof(PlayerModelReplacer.ToggleData.playerClientId)} = {toggleData.playerClientId}, " +
+                  $"{nameof(PlayerModelReplacer.ToggleData.playAudio)} = {toggleData.playAudio}, " +
+                  $"{nameof(PlayerModelReplacer.ToggleData.isDog)} = {toggleData.isDog} " +
+                  "}}");
+
+        PlayerModelReplacer replacer = null;
+        foreach (GameObject player in StartOfRound.Instance.allPlayerObjects)
+        {
+            var currentReplacer = player.GetComponent<PlayerModelReplacer>();
+            if (currentReplacer != null && currentReplacer.PlayerClientId == toggleData.playerClientId)
+            {
+                replacer = currentReplacer;
+                break;
+            }
+        }
+        if (replacer == null)
+        {
+            Debug.LogWarning($"{ModelSwitchMessageName} message from client {senderId} will be ignored because replacer with this ID is not registered");
+            return;
+        }
+
+        if (!replacer.IsValid)
+        {
+            Debug.LogError("Dog encountered an error when it was initialized and it can't be toggled. Check the log for more info.");
+            return;
+        }
+
+        Debug.Log($"Received dog={toggleData.isDog} for {replacer.PlayerClientId} ({replacer.PlayerUsername}).");
+
+        if (toggleData.isDog)
+        {
+            replacer.EnableDogModel(toggleData.playAudio);
+        }
+        else
+        {
+            replacer.EnableHumanModel(toggleData.playAudio);
+        }
+    }
+
+    private static void HandleModelInfoMessage(ulong senderId)
+    {
+        Debug.Log($"Got {ModelInfoMessageName} network message from {senderId}");
+        foreach (GameObject player in StartOfRound.Instance.allPlayerObjects)
+        {
+            var replacer = player.GetComponent<PlayerModelReplacer>();
+            if (replacer != null)
+            {
+                replacer.BroadcastSelectedModel(playAudio: false);
+            }
+        }
+    }
+}

--- a/PlayerDogModel.csproj
+++ b/PlayerDogModel.csproj
@@ -4,7 +4,7 @@
         <TargetFramework>netstandard2.1</TargetFramework>
         <AssemblyName>PlayerDogModel</AssemblyName>
         <Description>A mod to replace Player models with a dog for Lethal Company</Description>
-        <Version>1.0.2</Version>
+        <Version>1.0.3</Version>
         <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
         <LangVersion>latest</LangVersion>
     </PropertyGroup>

--- a/Plugin.cs
+++ b/Plugin.cs
@@ -1,14 +1,9 @@
 ﻿using BepInEx;
 using HarmonyLib;
 using System.Reflection;
-using LC_API;
 using GameNetcodeStuff;
 using UnityEngine;
-using UnityEngine.SceneManagement;
-using Unity.Netcode;
-using System;
 using System.IO;
-using System.Runtime.CompilerServices;
 using UnityEngine.Animations;
 
 namespace PlayerDogModel
@@ -26,6 +21,7 @@ namespace PlayerDogModel
 			_harmony.PatchAll();
 			Logger.LogInfo($"{PluginInfo.PLUGIN_GUID} loaded");
 
+			Networking.Initialize();
 			LC_API.BundleAPI.BundleLoader.LoadAssetBundle(GetAssemblyFullPath("playerdog"));
 		}
 

--- a/README.md
+++ b/README.md
@@ -62,3 +62,6 @@ Replaces the player models with a dog model!
 
 **[1.0.2]**
 - Fixed dogs not being visible when using Steam nicknames.
+
+**[1.0.3]**
+- Fixed models not syncing due to changes introduced with LC_API 3.2. It is now the minimum required version.


### PR DESCRIPTION
This should fix #11.

LC-API 3.2 introduced a new networking API, and while it did attempt to preserve backwards compatibility, it seems that this effort didn't go as planned so it doesn't work.

[A fix to the legacy API has been submitted here](https://github.com/steven4547466/LC-API/pull/20), but given that it's expected to be removed at some point, I figured I would update this mod to the new API.